### PR TITLE
Removing state pollution in `extracted_data_dict_1`

### DIFF
--- a/tests/integration/test_type_casting.py
+++ b/tests/integration/test_type_casting.py
@@ -284,6 +284,7 @@ def test_validate_types_no_removal(
     Unit: tests validate_types when there are not type conflicts.
     """
     # function invocation
+    extracted_data_dict_1 = copy.deepcopy(extracted_data_dict_1)
     validate_types(
         extracted_data_dict_1, drm_model_tax_coupon_with_inline_groups
     )

--- a/tests/integration/test_type_casting.py
+++ b/tests/integration/test_type_casting.py
@@ -35,7 +35,7 @@ def drm_model_tax_coupon_with_inline_groups():
     return drm
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def extracted_data_dict_1():
     return {
         "fields": {
@@ -284,7 +284,6 @@ def test_validate_types_no_removal(
     Unit: tests validate_types when there are not type conflicts.
     """
     # function invocation
-    extracted_data_dict_1 = copy.deepcopy(extracted_data_dict_1)
     validate_types(
         extracted_data_dict_1, drm_model_tax_coupon_with_inline_groups
     )

--- a/tests/integration/test_type_casting.py
+++ b/tests/integration/test_type_casting.py
@@ -300,12 +300,14 @@ def test_validate_types_removal(
     Unit: tests validate_types when there are type conflicts and
           some fields are removed.
     """
-    # creates a deep copy of the fixture so mutations wont affect next tests
-    extracted_data_dict = copy.deepcopy(extracted_data_dict_1)
+    # function invocation
+    validate_types(
+        extracted_data_dict_1, drm_model_tax_coupon_with_inline_groups
+    )
 
-    extracted_data_dict["fields"]["some_int"] = "abc123"  # messes int casting
+    extracted_data_dict_1["fields"]["some_int"] = "abc123"  # messes int casting
 
     # function invocation
-    validate_types(extracted_data_dict, drm_model_tax_coupon_with_inline_groups)
+    validate_types(extracted_data_dict_1, drm_model_tax_coupon_with_inline_groups)
 
-    assert extracted_data_dict == expected_extracted_data_dict_with_removal
+    assert extracted_data_dict_1 == expected_extracted_data_dict_with_removal


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_validate_types_no_removal` by 
avoiding state pollution in `extracted_data_dict_1` by calling method .`deepcopy`
The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/integration/test_type_casting.py::test_validate_types_no_removal`:

```
        # function invocation
        validate_types(
            extracted_data_dict_1, drm_model_tax_coupon_with_inline_groups
        )
    
>       assert extracted_data_dict_1 == expected_extracted_data_dict_no_removal
E       AssertionError: assert {'fields': {'...f1794,676'}]}} == {'fields': {'...f1794,676'}]}}
E         Omitting 1 identical items, use -vv to show
E         Differing items:
E         {'fields': {'cnpj': '10.549.937/000174', 'coo': '047621', 'some_int': 1234}} != {'fields': {'cnpj': '10.549.937/000174', 'coo': '047621', 'date': '1991-08-10T00:00:00', 'some_int': 1234}}
E         Full diff:
E           {
E            'fields': {'cnpj': '10.549.937/000174',
E                       'coo': '047621',...
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
