### PR TITLE
fix flaky test on test_drm_scanner.py::test_scan_drms_folder

### DIFF
--- a/regex4ocr/parser/drm_scanner.py
+++ b/regex4ocr/parser/drm_scanner.py
@@ -64,7 +64,7 @@ def scan_drms_folder(drms_path):
         (list): list of DRMs to parse the ocr result string.
     """
     base_path = os.path.join(drms_path, "")  # adds final flash of the directory
-    all_files = os.listdir(drms_path)
+    all_files = sorted(os.listdir(drms_path))
     drms = []
 
     for file in all_files:


### PR DESCRIPTION
This PR aims to fix the flaky test on **test_drm_scanner.py::test_scan_drms_folder**  so the test could pass single run, multiple test run, and random test run.

#### The result

The test won't pass on the single run with pytest or tox, the following error raised
` AssertionError: assert [{'fields': {'test1': 'key1', 'test2': 'key2', 'test3': 'key3'},\n  'identifiers': ['id1', 'id2', 'id2']},\n {'fields': {'test1': 'key1', 'test2': 'key2'}, 'identifiers': ['id1', 'id2']}] == [{'fields': {'test1': 'key1', 'test2': 'key2'}, 'identifiers': ['id1', 'id2']},\n {'fields': {'test1': 'key1', 'test2': 'key2', 'test3': 'key3'},\n  'identifiers': ['id1', 'id2', 'id2']}]
`

#### Steps to reproduce the issue

1.  run the test file with `tox` or `pytest .`

#### Issue of the code

The reason is that the test trying to assert two list of dictionary object read by `regex4ocr/parser/drm_scanner.py/scan_drms_folder `  function where it called the input file name is generated by 
`all_files = os.listdir(drms_path)`
However, when there are multipe file exist in the `drms_path` path, `os.listdir` doesn't guaranteed the return order of all file names.
see [source page](https://www.kite.com/python/answers/how-to-sort-directory-contents-in-python), "By default, the list of files returned by os.listdir() is in arbitrary order."
Therefore, when assuming the return order of the test function in `test_drm_scanner.py::test_scan_drms_folder` for `drm_1.yml` and `drm_1.yml`, the test fail on `assert all_drms == expected_drms`

#### Proposed solution
Adding a sort for the line `all_files = os.listdir(drms_path)` to `all_files = sorted(os.listdir(drms_path))` will fix the flakiness and let all test pass.

